### PR TITLE
goenvを削除する

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -34,11 +34,6 @@ export GOPATH=$HOME/go
 export PATH=$HOME/go/bin:$PATH
 export GOENV_DISABLE_GOPATH=1 # go1.13からの運用
 
-# for goenv
-export GOENV_ROOT="$HOME/.goenv"
-export PATH="$GOENV_ROOT/bin:$PATH"
-eval "$(goenv init -)"
-
 # for python
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"


### PR DESCRIPTION
公式から複数バージョンを扱う方法が明記されたので、そちらの運用に変更する