### PR TITLE
[update] pyenvのための環境設定を公式に合わせて書き換える

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -36,7 +36,7 @@ export GOENV_DISABLE_GOPATH=1 # go1.13からの運用
 
 # for python
 export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
+command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 
 # for pipenv


### PR DESCRIPTION
pyenvコマンドが失敗したらbin配下もパスに追加する
公式のREADMEを参考